### PR TITLE
Cast :db-before and :db-after returned by peer/transact to LocalDb for querying

### DIFF
--- a/test/compute/datomic_client_memdb/core_test.clj
+++ b/test/compute/datomic_client_memdb/core_test.clj
@@ -57,4 +57,7 @@
                     :where
                     [?e :user/name "bob"]] db))))
     (testing "db info works"
-      (is (every? some? (map #(get db % ) [:t :next-t :db-name]))))))
+      (is (every? some? (map #(get db %) [:t :next-t :db-name])))
+      (is (:t (last (d/tx-range conn {})))
+          (:t conn)))))
+


### PR DESCRIPTION
Now you can query against the result of the MemDB `transact` function:

```
(let [{:as rx :keys [db-after]} (dc/transact conn {:tx-data [...]})]
  (dc/q {:query {:find ... :where ...} :args [db-after]})
  (dc/q '{:find ... :where ...} db-after))
```

(maybe the update-vals helper is overkill here)