### PR TITLE
Add tests that demonstrate a query bug

### DIFF
--- a/test/compute/datomic_client_memdb/core_test.clj
+++ b/test/compute/datomic_client_memdb/core_test.clj
@@ -34,7 +34,10 @@
 (def test-schema [{:db/ident       :user/name
                    :db/valueType   :db.type/string
                    :db/cardinality :db.cardinality/one
-                   :db/index       true}])
+                   :db/index       true}
+                  {:db/ident       :user/heads
+                   :db/valueType   :db.type/long
+                   :db/cardinality :db.cardinality/one}])
 
 (deftest connection-test
   (d/create-database *client* {:db-name "test"})
@@ -57,7 +60,11 @@
   (let [conn (d/connect *client* {:db-name "test"})
         _ (d/transact conn {:tx-data test-schema})
         tx-report (d/transact conn {:tx-data [{:db/id     "bob"
-                                               :user/name "bob"}]})
+                                               :user/name "bob"
+                                               :user/heads 1}
+                                              {:db/id "alice"
+                                               :user/name "alice"
+                                               :user/heads 1}]})
         bob-id (get-in tx-report [:tempids "bob"])
         db (d/db conn)]
     (testing "query works"
@@ -65,6 +72,33 @@
              (d/q '[:find ?e
                     :where
                     [?e :user/name "bob"]] db))))
+    (testing "pull spec plus without :with works"
+      (is (= [[#:user{:name "bob"} 1]
+              [#:user{:name "alice"} 1]]
+             (d/q '[:find (pull ?e [:user/name]) (sum ?heads)
+                    :where
+                    [?e :user/heads ?heads]]
+                  db
+                  "bob"))))
+    (testing ":with without pull spec works"
+      (is (= [[2]]
+             (d/q '[:find (sum ?heads)
+                    :with ?name
+                    :where
+                    [?e :user/name ?name]
+                    [?e :user/heads ?heads]]
+                  db
+                  "bob"))))
+    (testing "pull spec plus :with is currently broken"
+      (is (= [[#:user{:name "bob"} 1]
+              [#:user{:name "alice"} 1]]
+             (d/q '[:find (pull ?e [:user/name]) (sum ?heads)
+                    :with ?name
+                    :where
+                    [?e :user/name ?name]
+                    [?e :user/heads ?heads]]
+                  db
+                  "bob"))))
     (testing "db info works"
       (is (every? some? (map #(get db %) [:t :next-t :db-name])))
       (is (:t (last (d/tx-range conn {})))
@@ -77,5 +111,4 @@
         (is (:tx-data tx-report))))
     (testing "index-range works"
       (let [[_ _ value] (first (d/index-range db {:attrid [:db/ident :user/name]}))]
-        (is (= value "bob"))))))
-
+        (is (= value "alice"))))))


### PR DESCRIPTION
It looks like using a pull spec in the same query as a :with clause
results in extra values being added to the results. I suspect the
":with variables" are being left in the results rather than being
stripped out, though the specific way this is happening is still
confusing to me.