### PR TITLE
Pull should return empty map when attribute does not exist

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
-{:deps    {com.datomic/client       {:mvn/version "0.8.69"}
+{:deps    {com.datomic/client       {:mvn/version "0.8.89"}
            com.datomic/datomic-free {:mvn/version "0.9.5697"}}
  :paths ["src"]
  :aliases {:test      {:extra-paths ["test"]}
            :run-tests {:extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                               :sha     "028a6d41ac9ac5d5c405dfc38e4da6b4cc1255d5"}}
+                                                               :sha     "f7ef16dc3b8332b0d77bc0274578ad5270fbfedd"}}
                        :main-opts  ["-m" "cognitect.test-runner"]}}}

--- a/src/compute/datomic_client_memdb/core.clj
+++ b/src/compute/datomic_client_memdb/core.clj
@@ -38,7 +38,11 @@
   (pull [this arg-map]
     (client/pull this (:selector arg-map) (:eid arg-map)))
   (pull [_ selector eid]
-    (peer/pull db selector eid))
+    ;; Datomic free will return nil when pull'ing for a single attribute that does
+    ;; not exist on an entity. Datomic Cloud returns {} in this case. Since there
+    ;; isn't any cases known where Datomic Cloud will return nil for a pull, we
+    ;; simply return an empty map if nil is returned from the Peer API.
+    (or (peer/pull db selector eid) {}))
   (since [_ t]
     (LocalDb. (peer/since db t) db-name))
   (with [_ arg-map]

--- a/test/compute/datomic_client_memdb/core_test.clj
+++ b/test/compute/datomic_client_memdb/core_test.clj
@@ -65,6 +65,12 @@
              (d/q '[:find ?e
                     :where
                     [?e :user/name "bob"]] db))))
+    (testing "pull works"
+      (is (= {:user/name "bob"}
+             (d/pull db '[:user/name] bob-id)))
+      (is (= {}
+             (d/pull db '[:user/i-dont-exist] bob-id))
+          "nonexistent attribute results in empty map, not nil"))
     (testing "db info works"
       (is (every? some? (map #(get db %) [:t :next-t :db-name])))
       (is (:t (last (d/tx-range conn {})))


### PR DESCRIPTION
Datomic free will return `nil` when `pull`'ing for a single attribute that does not exist on an entity. Datomic Cloud returns `{}` in this case. Since there isn't any cases known where Datomic Cloud will return `nil` for a `pull`, we simply return an empty map if `nil` is returned from the Peer API.