### PR TITLE
Fix incorrect return value from d/pull when eid is nil

### DIFF
--- a/src/compute/datomic_client_memdb/core.clj
+++ b/src/compute/datomic_client_memdb/core.clj
@@ -42,7 +42,14 @@
     ;; not exist on an entity. Datomic Cloud returns {} in this case. Since there
     ;; isn't any cases known where Datomic Cloud will return nil for a pull, we
     ;; simply return an empty map if nil is returned from the Peer API.
-    (or (peer/pull db selector eid) {}))
+    (if eid
+      (or (peer/pull db selector eid) {})
+      (throw (ex-info "Expected value for :eid"
+                      {:cognitect.anomalies/category                      :cognitect.anomalies/incorrect
+                       :cognitect.anomalies/message                       "Expected value for :eid"
+                       :datomic.client.impl.shared.validator/got          {:selector selector :eid eid}
+                       :datomic.client.impl.shared.validator/op           :pull
+                       :datomic.client.impl.shared.validator/requirements '{:eid value :selector value}}))))
   (since [_ t]
     (LocalDb. (peer/since db t) db-name))
   (with [_ arg-map]

--- a/test/compute/datomic_client_memdb/core_test.clj
+++ b/test/compute/datomic_client_memdb/core_test.clj
@@ -70,7 +70,9 @@
              (d/pull db '[:user/name] bob-id)))
       (is (= {}
              (d/pull db '[:user/i-dont-exist] bob-id))
-          "nonexistent attribute results in empty map, not nil"))
+          "nonexistent attribute results in empty map, not nil")
+      (is (thrown? ExceptionInfo (d/pull db [:user/name] nil))
+          "exception thrown when pulling nil eid"))
     (testing "db info works"
       (is (every? some? (map #(get db %) [:t :next-t :db-name])))
       (is (:t (last (d/tx-range conn {})))


### PR DESCRIPTION
### Expected
```clojure
(d/pull db '[*] nil)
clojure.lang.ExceptionInfo: Expected value for :eid
                         cognitect.anomalies/category: :cognitect.anomalies/incorrect
                          cognitect.anomalies/message: "Expected value for :eid"
             datomic.client.impl.shared.validator/got: {:selector [*], :eid nil}
              datomic.client.impl.shared.validator/op: :pull
    datomic.client.impl.shared.validator/requirements: {:eid value, :selector value}
```
### Actual 
```clojure
(d/pull db '[*] nil)
=> #:db{:id nil}
```